### PR TITLE
Better mouse input

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -103,7 +103,6 @@ const char *sdl_video_window_pos;
 static void ActivateMouse(void);
 static void DeactivateMouse(void);
 //static int AccelerateMouse(int val);
-static void I_ReadMouse(void);
 static dboolean MouseShouldBeGrabbed();
 static void UpdateFocus(void);
 
@@ -1506,44 +1505,12 @@ static void DeactivateMouse(void)
   SDL_SetRelativeMouseMode(SDL_FALSE);
 }
 
-//
-// Read the change in mouse state to generate mouse motion events
-//
-// This is to combine all mouse movement for a tic into one mouse
-// motion event.
-
-static void SmoothMouse(int* x, int* y)
-{
-    static int x_remainder_old = 0;
-    static int y_remainder_old = 0;
-
-    int x_remainder, y_remainder;
-    fixed_t correction_factor;
-
-    const fixed_t fractic = I_TickElapsedTime();
-
-    *x += x_remainder_old;
-    *y += y_remainder_old;
-
-    correction_factor = FixedDiv(fractic, FRACUNIT + fractic);
-
-    x_remainder = FixedMul(*x, correction_factor);
-    *x -= x_remainder;
-    x_remainder_old = x_remainder;
-
-    y_remainder = FixedMul(*y, correction_factor);
-    *y -= y_remainder;
-    y_remainder_old = y_remainder;
-}
-
-static void I_ReadMouse(void)
+void I_ReadMouse(void)
 {
   if (mouse_enabled && window_focused)
   {
     int x, y;
-
     SDL_GetRelativeMouseState(&x, &y);
-    SmoothMouse(&x, &y);
 
     if (x != 0 || y != 0)
     {

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1517,8 +1517,8 @@ void I_ReadMouse(void)
       event_t event;
       event.type = ev_mousemotion;
       event.data1 = 0;
-      event.data2 = x << 4;
-      event.data3 = -y << 4;
+      event.data2 = x;
+      event.data3 = -y;
 
       D_PostEvent(&event);
     }

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -436,6 +436,10 @@ void D_Display (fixed_t frac)
     // e6y
     // Boom colormaps should be applied for everything in R_RenderPlayerView
     use_boom_cm=true;
+    
+    // Accumulate mouse inputs for render angles
+    SDL_PumpEvents();
+    I_ReadMouse();
 
     R_InterpolateView(&players[displayplayer], frac);
 

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -1083,6 +1083,7 @@ int AccelerateMouse(int val)
 }
 
 int mlooky = 0;
+int mlooky_remainder = 0;
 
 void e6y_G_Compatibility(void)
 {

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -745,7 +745,15 @@ void M_MouseMLook(int choice)
 
 void M_MouseAccel(int choice)
 {
-  M_Mouse(choice, &mouse_acceleration);
+  switch(choice)
+  {
+  case 0:
+    mouse_acceleration = MAX(mouse_acceleration - 1, 0);
+    break;
+  case 1:
+    mouse_acceleration = MIN(mouse_acceleration + 1, 99);
+    break;
+  }
   MouseAccelChanging();
 }
 

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -313,6 +313,7 @@ int AccelerateMouse(int val);
 void MouseAccelChanging(void);
 
 extern int mlooky;
+extern int mlooky_remainder;
 extern int realtic_clock_rate;
 
 void e6y_G_Compatibility(void);

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -172,6 +172,9 @@ extern float skyXShift;
 extern float skyYShift;
 extern dboolean mlook_or_fov;
 
+extern int maxViewPitch;
+extern int minViewPitch;
+
 extern hu_textline_t  w_hudadd;
 extern hu_textline_t  w_centermsg;
 extern hu_textline_t  w_precache;

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -75,6 +75,7 @@ typedef struct camera_s
   angle_t PrevAngle;
   angle_t PrevPitch;
   int type;
+  int keyboardangleturn;
 } camera_t;
 
 extern dboolean wasWiped;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -4434,6 +4434,8 @@ void P_WalkTicker()
       if (joyxmove < 0)
         angturn += angleturn[tspeed];
     }
+    
+  walkcamera.keyboardangleturn = angturn;
 
   if (gamekeydown[key_up])
     forward += forwardmove[speed];

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -334,8 +334,8 @@ static int mousearray[MAX_MOUSEB + 1];
 static int *mousebuttons = &mousearray[1];    // allow [-1]
 
 // mouse values are used once
-static int   mousex;
-static int   mousex_remainder;
+int          mousex;
+int          mousex_remainder;
 static int   mousey;
 static int   mousey_remainder;
 static int   dclicktime;
@@ -1103,14 +1103,16 @@ dboolean G_Responder (event_t* ev)
       //e6y mousey += (ev->data3*(mouseSensitivity_vert))/10;  /*Mead rm *4 */
 
       //e6y
-      AccumulateMouse(ev->data2, mouseSensitivity_horiz, 10, &mousex, &mousex_remainder);
+      AccumulateMouse(ev->data2, mouseSensitivity_horiz, MOUSEX_RATIO, &mousex, &mousex_remainder);
       if(GetMouseLook())
-        if (movement_mouseinvert)
-          AccumulateMouse(ev->data3, mouseSensitivity_mlook, 10, &mlooky, &mlooky_remainder);
-        else
-          AccumulateMouse(-ev->data3, mouseSensitivity_mlook, 10, &mlooky, &mlooky_remainder);
+      {
+        int y = movement_mouseinvert ? ev->data3 : -ev->data3;
+        AccumulateMouse(y, mouseSensitivity_mlook, MLOOKY_RATIO, &mlooky, &mlooky_remainder);
+      }
       else
-        AccumulateMouse(ev->data3, mouseSensitivity_vert, 40, &mousey, &mousey_remainder);
+      {
+        AccumulateMouse(ev->data3, mouseSensitivity_vert, MOUSEY_RATIO, &mousey, &mousey_remainder);
+      }
 
       return true;    // eat events
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -306,7 +306,8 @@ fixed_t sidemove_strafe50[2]  = {0x19, 0x32};
 // CPhipps - made lots of key/button state vars static
 //e6y static
 dboolean gamekeydown[NUMKEYS];
-static int     turnheld;       // for accelerative turning
+static int     turnheld;          // for accelerative turning
+int            keyboardangleturn; // angleturn contribution from keyboard on last cmd
 
 // Set to -1 or +1 to switch to the previous or next weapon.
 
@@ -586,6 +587,8 @@ void G_BuildTiccmd(ticcmd_t* cmd)
       if (joyxmove < 0)
         cmd->angleturn += angleturn[tspeed];
     }
+    
+  keyboardangleturn = cmd->angleturn;
 
   if (gamekeydown[key_up])
     forward += forwardmove[speed];

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -45,6 +45,11 @@
 // killough 5/2/98: number of bytes reserved for saving options
 #define GAME_OPTION_SIZE 64
 
+// mouse sensitivity scaling divisors
+#define MOUSEX_RATIO 10
+#define MLOOKY_RATIO 10
+#define MOUSEY_RATIO 40
+
 dboolean G_Responder(event_t *ev);
 dboolean G_CheckDemoStatus(void);
 void G_DeathMatchSpawnPlayer(int playernum);
@@ -223,6 +228,9 @@ extern int  joybstrafeleft;
 extern int  joybstraferight;
 extern int  joybuse;
 extern int  joybspeed;
+
+extern int  mousex;
+extern int  mousex_remainder;
 
 extern int  key_timewarp_forward;
 extern int  key_timewarp_backward;

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -46,9 +46,9 @@
 #define GAME_OPTION_SIZE 64
 
 // mouse sensitivity scaling divisors
-#define MOUSEX_RATIO 10
-#define MLOOKY_RATIO 10
-#define MOUSEY_RATIO 40
+#define MOUSEX_RATIO 16
+#define MLOOKY_RATIO 16
+#define MOUSEY_RATIO 64
 
 dboolean G_Responder(event_t *ev);
 dboolean G_CheckDemoStatus(void);

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -229,6 +229,8 @@ extern int  joybstraferight;
 extern int  joybuse;
 extern int  joybspeed;
 
+extern int  keyboardangleturn;
+
 extern int  mousex;
 extern int  mousex_remainder;
 

--- a/prboom2/src/i_video.h
+++ b/prboom2/src/i_video.h
@@ -115,6 +115,7 @@ extern int process_priority;
 extern int vanilla_keymap;
 
 extern dboolean window_focused;
+void I_ReadMouse(void);
 void UpdateGrab(void);
 
 #endif

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1400,6 +1400,8 @@ menu_t MouseDef =
 
 #define MOUSE_SENS_MAX 100
 
+#define MOUSE_SENS_SCALE 8u
+
 //
 // Change Mouse Sensitivities -- killough
 //
@@ -1412,18 +1414,18 @@ void M_DrawMouse(void)
   V_DrawNamePatch(60, 15, 0, "M_MSENS", CR_DEFAULT, VPT_STRETCH);//e6y
 
   //jff 4/3/98 clamp horizontal sensitivity display
-  mhmx = mouseSensitivity_horiz>99? 99 : mouseSensitivity_horiz; /*mead*/
+  mhmx = MIN(mouseSensitivity_horiz / MOUSE_SENS_SCALE, 99); /*mead*/
   M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_horiz+1),100,mhmx);
   //jff 4/3/98 clamp vertical sensitivity display
-  mvmx = mouseSensitivity_vert>99? 99 : mouseSensitivity_vert; /*mead*/
+  mvmx = MIN(mouseSensitivity_vert / MOUSE_SENS_SCALE, 99); /*mead*/
   M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_vert+1),100,mvmx);
 
   //e6y
   {
     int mpmx;
-    mpmx = mouseSensitivity_mlook>99? 99 : mouseSensitivity_mlook;
+    mpmx = MIN(mouseSensitivity_mlook / MOUSE_SENS_SCALE, 99);
     M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_mlook+1),100,mpmx);
-    mpmx = mouse_acceleration>99? 99 : mouse_acceleration;
+    mpmx = MIN(mouse_acceleration, 99);
     M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_accel+1),100,mpmx);
   }
 }
@@ -1460,12 +1462,10 @@ void M_Mouse(int choice, int *sens)
   switch(choice)
     {
     case 0:
-      if (*sens)
-        --*sens;
+      *sens = MAX(*sens - MOUSE_SENS_SCALE, 0);
       break;
     case 1:
-      if (*sens < 99)
-        ++*sens;              /*mead*/
+      *sens = MIN(*sens + MOUSE_SENS_SCALE, 99 * MOUSE_SENS_SCALE);
       break;
     }
 }

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -581,10 +581,10 @@ default_t defaults[] =
   {"use_mouse",{&usemouse},{1},0,1,
    def_bool,ss_none}, // enables use of mouse with DOOM
   //jff 4/3/98 allow unlimited sensitivity
-  {"mouse_sensitivity_horiz",{&mouseSensitivity_horiz},{10},0,UL,
+  {"mouse_sensitivity_horiz",{&mouseSensitivity_horiz},{256},0,UL,
    def_int,ss_none}, /* adjust horizontal (x) mouse sensitivity killough/mead */
   //jff 4/3/98 allow unlimited sensitivity
-  {"mouse_sensitivity_vert",{&mouseSensitivity_vert},{1},0,UL,
+  {"mouse_sensitivity_vert",{&mouseSensitivity_vert},{24},0,UL,
    def_int,ss_none}, /* adjust vertical (y) mouse sensitivity killough/mead */
   //jff 3/8/98 allow -1 in mouse bindings to disable mouse function
   {"mouseb_fire",{&mousebfire},{0},-1,MAX_MOUSEB,
@@ -1071,7 +1071,7 @@ default_t defaults[] =
   {"PrboomX mouse settings",{NULL},{0},UL,UL,def_none,ss_none},
   {"mouse_acceleration",{&mouse_acceleration},{0},0,UL,
    def_int,ss_none},
-  {"mouse_sensitivity_mlook",{&mouseSensitivity_mlook},{10},0,UL,
+  {"mouse_sensitivity_mlook",{&mouseSensitivity_mlook},{256},0,UL,
    def_int,ss_none},
   {"mouse_doubleclick_as_use", {&mouse_doubleclick_as_use},  {1},0,1,
    def_bool,ss_stat},

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -106,12 +106,12 @@ static dboolean CanPlayerFreeLook(player_t *player)
   return CanPlayerTurn(player) && (!(automapmode & am_active) || (automapmode & am_overlay));
 }
 
-static angle_t GetAccumulatedAngle()
+static fixed_t GetAccumulatedAngle()
 {
   return -((mousex << 16) + (mousex_remainder << 16) / MOUSEX_RATIO);
 }
 
-static angle_t GetAccumulatedPitch()
+static fixed_t GetAccumulatedPitch()
 {
   return +((mlooky << 16) + (mlooky_remainder << 16) / MLOOKY_RATIO);
 }
@@ -119,6 +119,12 @@ static angle_t GetAccumulatedPitch()
 static angle_t ClampPitch(angle_t pitch)
 {
   return (angle_t)BETWEEN(minViewPitch, maxViewPitch, (int)pitch);
+}
+
+static fixed_t GetKeyboardTurnInterpAngle(fixed_t frac)
+{
+  // interpolate keyboard turning as an offset from the current angle
+  return (FixedMul(frac, keyboardangleturn) - keyboardangleturn) << 16;
 }
 
 void R_InterpolateView(player_t *player, fixed_t frac)
@@ -181,7 +187,7 @@ void R_InterpolateView(player_t *player, fixed_t frac)
     else
     {
       viewangle = accumulate_angle
-          ? R_SmoothPlaying_Get(player) + GetAccumulatedAngle()
+          ? R_SmoothPlaying_Get(player) + GetAccumulatedAngle() + GetKeyboardTurnInterpAngle(frac)
           : player->prev_viewangle + FixedMul (frac, R_SmoothPlaying_Get(player) - player->prev_viewangle);
       viewpitch = accumulate_pitch
           ? ClampPitch(player->mo->pitch + GetAccumulatedPitch())

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -180,8 +180,6 @@ void R_InterpolateView(player_t *player, fixed_t frac)
     }
     else
     {
-      //doom_printf("%u", GetAccumulatedAngle());
-      doom_printf("huh %d", mousex);
       viewangle = accumulate_angle
           ? R_SmoothPlaying_Get(player) + GetAccumulatedAngle()
           : player->prev_viewangle + FixedMul (frac, R_SmoothPlaying_Get(player) - player->prev_viewangle);


### PR DESCRIPTION
Samples mouse input each frame and updates the render angles rather than interpolating. Interpolation is preserved for keyboard turning. The sensitivity cvars use a significantly more precise scale. The menu adjusts them in increments of 8.

Framerate dependent mouse accel is a known issue.