### PR TITLE
Fix rounding error in ammo colours

### DIFF
--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -1399,9 +1399,9 @@ int HU_GetAmmoColor(int ammo, int fullammo, int def, int tofire, dboolean backpa
     (ammo_colour_behaviour == ammo_colour_behaviour_no && backpack && ammo*2 >= fullammo))
     result=def;
   else {
-    ammopct = (100 * ammo) / fullammo;
-    if (backpack && ammo_colour_behaviour != ammo_colour_behaviour_yes)
-      ammopct *= 2;
+      ammopct = (((backpack &&
+		   (ammo_colour_behaviour != ammo_colour_behaviour_yes))
+		  ? 200 : 100) * ammo) / fullammo;
     if (ammopct < ammo_red)
       result = CR_RED;
     else if (ammopct < ammo_yellow)
@@ -1775,12 +1775,17 @@ void HU_widget_build_weapon(void)
       (ammo_colour_behaviour == ammo_colour_behaviour_no &&
       plr->backpack && ammo*2 >= fullammo)))
       hud_weapstr[i++] = '0'+CR_BLUE;
-    else
-    {
-      ammopct = fullammo ? (100*ammo)/fullammo : 100;
-      if (plr->backpack && fullammo &&
-        ammo_colour_behaviour != ammo_colour_behaviour_yes)
-        ammopct *= 2;
+    else {
+      if (fullammo) {
+	ammopct = (plr->backpack &&
+		   ammo_colour_behaviour != ammo_colour_behaviour_yes) ?
+	200 : 100;
+	ammopct *=ammo; ammopct /= fullammo;
+      } else {
+// I'm not sure we can get here - are there weapons where fullammo = 0 but
+// not weaponinfo[w].ammo==am_noammo? But it's been this way since 2010...
+	ammopct = 100; 
+      }
       if (ammopct<ammo_red)
         hud_weapstr[i++] = '0'+CR_RED;
       else if (ammopct<ammo_yellow)

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -858,9 +858,10 @@ static void ST_drawWidgets(dboolean refresh)
     STlib_updateNum(&w_ready, CR_BLUE2, refresh);
   else {
     if (plyr->maxammo[weaponinfo[w_ready.data].ammo])
-      ammopct = (*w_ready.num*100)/plyr->maxammo[weaponinfo[w_ready.data].ammo];
-    if (plyr->backpack && ammo_colour_behaviour != ammo_colour_behaviour_yes)
-      ammopct *= 2;
+	ammopct = (((plyr->backpack &&
+		     (ammo_colour_behaviour != ammo_colour_behaviour_yes))
+		    ? 200: 100) * *w_ready.num /
+		   plyr->maxammo[weaponinfo[w_ready.data].ammo]);
     if (ammopct < ammo_red)
       STlib_updateNum(&w_ready, CR_RED, refresh);
     else


### PR DESCRIPTION
commit 6811dbe6d3848b358eb8c0a2b50fcfe71e84eecc (written by me, oops) introduced a rounding error most easily seen by setting option ammo_color_behavior to "no" and ammo_red or ammo_yellow to an odd number and firing off chaingun ammo; the colour displayed on the HUD / status bar will change too early. This is because integer division rounds down before the "ammopct *= 2".

This commit fixes that bug. Sorry I spotted it in, er, 2016 and then forgot about it for nine years.