### PR TITLE
Add option to control maximum health/armour HUD bars reflect

### DIFF
--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -3208,6 +3208,7 @@ static int HU_count_health_bars(void) {
 	divisor = 100;
 	break;
     }
+    if (divisor <= 0) divisor = 100;
     // We can't just do "(numerator * HUD_MAX_BARS) / (divisor * 100)" here
     // it would integer overflow with 16-bit ints and max health > 320
     result = numerator / (divisor * (100 / HUD_MAX_BARS));
@@ -3232,6 +3233,7 @@ static int HU_count_armor_bars(void) {
 	divisor = 1;
 	break;
     }
+    if (divisor <= 0) divisor = 1;
     result = numerator / (divisor * (100 / HUD_MAX_BARS));
     return (result > HUD_MAX_BARS) ? HUD_MAX_BARS : result;
 }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2860,9 +2860,11 @@ setup_menu_t stat_settings1[] =  // Status Bar and HUD Settings screen
   {"ARMOR LOW/OK"      ,S_NUM       ,m_null,SB_X,SB_Y+11*8, {"armor_red"}},
   {"ARMOR OK/GOOD"     ,S_NUM       ,m_null,SB_X,SB_Y+12*8, {"armor_yellow"}},
   {"ARMOR GOOD/EXTRA"  ,S_NUM       ,m_null,SB_X,SB_Y+13*8, {"armor_green"}},
-  {"AMMO LOW/OK"       ,S_NUM       ,m_null,SB_X,SB_Y+14*8, {"ammo_red"}},
-  {"AMMO OK/GOOD"      ,S_NUM       ,m_null,SB_X,SB_Y+15*8, {"ammo_yellow"}},
-  {"BACKPACK CHANGES THRESHOLDS",S_CHOICE,m_null,SB_X,SB_Y+16*8, 
+  {"MAXIMUM VALUE FOR HUD BAR",S_CHOICE,m_null,SB_X,SB_Y+14*8,
+   {"hud_bar_maximum"},0,0,NULL,hud_bar_maximum_list},
+  {"AMMO LOW/OK"       ,S_NUM       ,m_null,SB_X,SB_Y+15*8, {"ammo_red"}},
+  {"AMMO OK/GOOD"      ,S_NUM       ,m_null,SB_X,SB_Y+16*8, {"ammo_yellow"}},
+  {"BACKPACK CHANGES THRESHOLDS",S_CHOICE,m_null,SB_X,SB_Y+17*8, 
    {"ammo_colour_behaviour"},0,0,NULL,ammo_colour_behaviour_list},
 
   // Button for resetting to defaults

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -992,6 +992,9 @@ default_t defaults[] =
    def_int,ss_stat}, // amount of armor for yellow to green transition
   {"armor_green",   {&armor_green}  , {100},0,200,// below is green, above blue
    def_int,ss_stat}, // amount of armor for green to blue transition
+  {"hud_bar_maximum",{(int*)&hud_bar_maximum},
+   {2}, // health/armor bars go to 100 / 200 / dehacked max
+   0,hud_bar_maximum_max-1,def_int,ss_stat},
   {"ammo_red",      {&ammo_red}     , {25},0,100, // below 25% is red
    def_int,ss_stat}, // percent of ammo for red to yellow transition
   {"ammo_yellow",   {&ammo_yellow}  , {50},0,100, // below 50% is yellow, above green

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -336,6 +336,14 @@ int armor_red;     // armor amount less than which status is red
 int armor_yellow;  // armor amount less than which status is yellow
 int armor_green;   // armor amount above is blue, below is green
 
+hud_bar_maximum_t hud_bar_maximum;
+const char *hud_bar_maximum_list[hud_bar_maximum_max] = {
+  "100/100",
+  "200/200",
+  "medikit/green",
+  "soulsphere/blue"
+};
+
 ammo_colour_behaviour_t ammo_colour_behaviour;
 const char *ammo_colour_behaviour_list[ammo_colour_behaviour_max] = {
   "no",

--- a/prboom2/src/st_stuff.h
+++ b/prboom2/src/st_stuff.h
@@ -111,6 +111,16 @@ extern int sts_armorcolor_type;  // armor color depends on type
 extern int st_palette;    // cph 2006/04/06 - make palette visible
 
 typedef enum {
+    hud_bar_maximum_hundred,
+    hud_bar_maximum_twohundred,
+    hud_bar_maximum_deh,
+    hud_bar_maximum_deh_super,
+    hud_bar_maximum_max
+} hud_bar_maximum_t;
+extern hud_bar_maximum_t hud_bar_maximum;
+extern const char *hud_bar_maximum_list[];
+
+typedef enum {
   ammo_colour_behaviour_no,
   ammo_colour_behaviour_full_only,
   ammo_colour_behaviour_yes,


### PR DESCRIPTION
(as discussed in issue #20 ...)

This allows a full-width HUD bar to reflect either 100 health/armour (the default, matching the previous behaviour), 200 (letting you see how much soulsphere / blue armour health is left), or the maximum medkit / green armour  or soulsphere / blue armour health set in DeHacked.

I don't think it's a no-brainer to have only the latter two behaviours, although without DeHacked medkit/green armour is indistinguishable from 100/100, because even with a DeHacked patch increasing maximum health, the player may be looking for a sense of the number of fireballs that will kill them.

However, the patch could be simplified by removing hud_bar_maximum_hundred and hud_bar_maximum_twohundred if that isn't felt to be a serious concern.