### PR TITLE
Force C standard to C99 and ignore incompatible pointer errors

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.0...4.0)
 project("PrBoomX"
     VERSION 2.9.0
     HOMEPAGE_URL "https://github.com/JadingTsunami/prboomX")
+set (CMAKE_C_STANDARD 99)
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")
@@ -210,7 +211,7 @@ else()
         -Wall -Wno-missing-field-initializers -Wwrite-strings -Wundef \
         -Wbad-function-cast -Wcast-align -Wcast-qual -Wdeclaration-after-statement \
         -Wpointer-arith -Wno-unused -Wno-switch -Wno-sign-compare -Wno-pointer-sign \
-        -ffast-math"
+        -ffast-math -Wno-error=incompatible-pointer-types"
     )
 endif()
 


### PR DESCRIPTION
This is to fix the issue described in #28.

# Overview of Changes
* Force C standard in CMakeLists.txt
* Add `-Wno-error=incompatible-pointer-types` to C_FLAGS